### PR TITLE
Implement API endpoints for hourly, daily and paginated data (#23)

### DIFF
--- a/server/Program.cs
+++ b/server/Program.cs
@@ -33,6 +33,47 @@ app.MapGet("/api/sensorData/{id}", async (int id, SensorDataContext db, ILogger<
     return Results.Ok(sensorReading);
 });
 
+app.MapGet("/api/sensorData/hourly", async (DateTime date, int hour, ILogger<Program> logger, SensorDataContext context) =>
+{
+    var hourlyAggregates = await context.SensorReadingsHourly
+        .Where(ha => ha.Hour.Date == date.Date && ha.Hour.Hour == hour)
+        .ToListAsync();
+
+    return hourlyAggregates.Count != 0 ? Results.Ok(hourlyAggregates) : Results.NotFound();
+});
+
+app.MapGet("/api/sensorData/daily", async (DateTime date, ILogger<Program> logger, SensorDataContext context) =>
+{
+    var dailyAggregates = await context.SensorReadingsDaily
+        .Where(da => da.Date == date.Date)
+        .ToListAsync();
+
+    return dailyAggregates.Count != 0 ? Results.Ok(dailyAggregates) : Results.NotFound();
+});
+
+app.MapGet("/api/sensorData", async (SensorDataContext context, int pageNumber = 1, int pageSize = 100) =>
+{
+    var totalRecords = await context.SensorReadings.CountAsync();
+    var totalPages = (int)Math.Ceiling(totalRecords / (double)pageSize);
+
+    var sensorReadings = await context.SensorReadings
+        .OrderBy(sr => sr.Timestamp)
+        .Skip((pageNumber - 1) * pageSize)
+        .Take(pageSize)
+        .ToListAsync();
+
+    var response = new
+    {
+        TotalRecords = totalRecords,
+        TotalPages = totalPages,
+        CurrentPage = pageNumber,
+        PageSize = pageSize,
+        Data = sensorReadings
+    };
+
+    return Results.Ok(response);
+});
+
 app.MapPost("/api/sensorData", async (SensorReading sensorReading, ILogger<Program> logger, SensorDataContext db) =>
 {
     logger.LogInformation("Received sensor data: {sensorReading}", sensorReading);


### PR DESCRIPTION
Adds 3 new API endpoints: one for aggregated daily, aggregated hourly, and paginated sensor readings respectively.

closes #23 