### PR TITLE
Add Unit Tests for API key Middleware and Aggregation Service

### DIFF
--- a/tests/serverTests/Middleware/ApiKeyPostMiddlewareTests.cs
+++ b/tests/serverTests/Middleware/ApiKeyPostMiddlewareTests.cs
@@ -1,0 +1,121 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
+
+using project_frej.Middleware;
+
+namespace project_frej.Tests.Middleware
+{
+    public class ApiKeyPostMiddlewareTests
+    {
+        private static IHostBuilder CreateHostBuilder(string endpoint, Action<IEndpointRouteBuilder> configure)
+        {
+            return Host.CreateDefaultBuilder()
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseTestServer()
+                    .ConfigureAppConfiguration((context, config) =>
+                    {
+                        config.AddInMemoryCollection(new Dictionary<string, string?>
+                        {
+                            { "ApiKey", "supersecretkey" }
+                        });
+                    })
+                    .ConfigureServices(services =>
+                    {
+                        services.AddLogging(builder =>
+                        {
+                            builder.ClearProviders(); // remove all logging providers
+                            builder.AddFilter("Microsoft", LogLevel.None); // disable Microsoft logs
+                        });
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseMiddleware<ApiKeyPostMiddleware>();
+                        app.UseRouting();
+                        app.UseEndpoints(configure);
+                    });
+                });
+        }
+
+        [Fact]
+        public async Task ContinuesForNonPostRequest()
+        {
+            var host = await CreateHostBuilder("/testGet", endpoints =>
+            {
+                endpoints.MapGet("/", async context =>
+                {
+                    await context.Response.WriteAsync("GET request received");
+                });
+            }).StartAsync();
+
+            var client = host.GetTestClient();
+            var response = await client.GetAsync("/");
+
+            Assert.Equal(200, (int)response.StatusCode);
+            Assert.Equal("GET request received", await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task ReturnsUnauthorizedForMissingApiKey()
+        {
+            var host = await CreateHostBuilder("/", endpoints =>
+            {
+                endpoints.MapPost("/", async context =>
+                {
+                    await context.Response.WriteAsync("Received");
+                });
+            }).StartAsync();
+
+            var client = host.GetTestClient();
+            var response = await client.PostAsync("/", new StringContent(""));
+
+            Assert.Equal(401, (int)response.StatusCode);
+        }
+
+        [Fact]
+        public async Task ReturnsUnauthorizedForInvalidApiKey()
+        {
+            var host = await CreateHostBuilder("/", endpoints =>
+            {
+                endpoints.MapPost("/", async context =>
+                {
+                    await context.Response.WriteAsync("Received");
+                });
+            }).StartAsync();
+
+            var client = host.GetTestClient();
+            var request = new HttpRequestMessage(HttpMethod.Post, "/");
+            request.Headers.Add("Authorization", "invalidkey");
+            var response = await client.SendAsync(request);
+
+            Assert.Equal(401, (int)response.StatusCode);
+        }
+
+        [Fact]
+        public async Task ReturnsAuthorizedForValidApiKey()
+        {
+            var host = await CreateHostBuilder("/", endpoints =>
+            {
+                endpoints.MapPost("/", async context =>
+                {
+                    await context.Response.WriteAsync("Received");
+                });
+            }).StartAsync();
+
+            var client = host.GetTestClient();
+            var request = new HttpRequestMessage(HttpMethod.Post, "/");
+            request.Headers.Add("Authorization", "supersecretkey");
+            var response = await client.SendAsync(request);
+
+            Assert.Equal(200, (int)response.StatusCode);
+            Assert.Equal("Received", await response.Content.ReadAsStringAsync());
+        }
+    }
+}

--- a/tests/serverTests/Services/AggregationServiceTests.cs
+++ b/tests/serverTests/Services/AggregationServiceTests.cs
@@ -1,0 +1,140 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+using project_frej.Data;
+using project_frej.Models;
+using project_frej.Services;
+
+namespace project_frej.Tests.Services
+{
+    public class AggregationServiceTests : IDisposable
+    {
+        private SqliteConnection _connection;
+        private SensorDataContext _context;
+        private AggregationService _service;
+
+        public AggregationServiceTests()
+        {
+            _connection = new SqliteConnection("DataSource=:memory:");
+            _connection.Open();
+
+            var options = new DbContextOptionsBuilder<SensorDataContext>()
+                .UseSqlite(_connection)
+                .Options;
+
+            _context = new SensorDataContext(options);
+            _context.Database.EnsureCreated();
+
+            _service = new AggregationService(_context);
+        }
+
+        [Fact]
+        public async Task AggregateDailyData_CorrectWhenReadingsExist()
+        {
+            var date = new DateTime(1998, 7, 16);
+            _context.SensorReadings.AddRange(
+                new SensorReading { Pressure = 100, Temperature = 20, Humidity = 50, Lux = 300, Uvs = 1, Gas = 10, Timestamp = date.AddHours(1) },
+                new SensorReading { Pressure = 200, Temperature = 22, Humidity = 55, Lux = 320, Uvs = 3, Gas = 12, Timestamp = date.AddHours(2) }
+            );
+
+            await _context.SaveChangesAsync();
+
+            await _service.AggregateDailyData(date);
+
+            var aggregate = await _context.SensorReadingsDaily.FirstOrDefaultAsync(a => a.Date == date);
+            Assert.NotNull(aggregate);
+            Assert.Equal(150, aggregate.AvgPressure);
+            Assert.Equal(200, aggregate.MaxPressure);
+            Assert.Equal(100, aggregate.MinPressure);
+        }
+
+        [Fact]
+        public async Task AggregateDailyData_CorrectWhenNoReadingsExist()
+        {
+            var date = new DateTime(1998, 7, 16);
+
+            await _service.AggregateDailyData(date);
+
+            var aggregate = await _context.SensorReadingsDaily.FirstOrDefaultAsync(a => a.Date == date);
+            Assert.Null(aggregate);
+        }
+
+        [Fact]
+        public async Task AggregateDailyData_OnlyAggregateForGivenDate()
+        {
+            var date = new DateTime(1998, 7, 16);
+            _context.SensorReadings.AddRange(
+                new SensorReading { Pressure = 100, Temperature = 20, Humidity = 50, Lux = 300, Uvs = 1, Gas = 10, Timestamp = date.AddHours(1) },
+                new SensorReading { Pressure = 200, Temperature = 22, Humidity = 55, Lux = 320, Uvs = 3, Gas = 12, Timestamp = date.AddDays(1) }
+            );
+
+            await _context.SaveChangesAsync();
+
+            await _service.AggregateDailyData(date);
+
+            var aggregate = await _context.SensorReadingsDaily.FirstOrDefaultAsync(a => a.Date == date);
+            Assert.NotNull(aggregate);
+            Assert.Equal(100, aggregate.AvgPressure);
+            Assert.Equal(100, aggregate.MaxPressure);
+            Assert.Equal(100, aggregate.MinPressure);
+        }
+
+        [Fact]
+        public async Task AggregateHourlyData_CorrectWhenReadingsExist()
+        {
+            var date = new DateTime(1998, 7, 16);
+            _context.SensorReadings.AddRange(
+                new SensorReading { Pressure = 100, Temperature = 20, Humidity = 50, Lux = 300, Uvs = 1, Gas = 10, Timestamp = date.AddHours(1) },
+                new SensorReading { Pressure = 200, Temperature = 22, Humidity = 55, Lux = 320, Uvs = 3, Gas = 12, Timestamp = date.AddHours(1) }
+            );
+
+            await _context.SaveChangesAsync();
+
+            await _service.AggregateHourlyData(date, 1);
+
+            var aggregate = await _context.SensorReadingsHourly.FirstOrDefaultAsync(a => a.Hour == date.AddHours(1));
+            Assert.NotNull(aggregate);
+            Assert.Equal(150, aggregate.AvgPressure);
+            Assert.Equal(200, aggregate.MaxPressure);
+            Assert.Equal(100, aggregate.MinPressure);
+        }
+
+        [Fact]
+        public async Task AggregateHourlyData_CorrectWhenNoReadingsExist()
+        {
+            var date = new DateTime(1998, 7, 16);
+
+            await _service.AggregateHourlyData(date, 1);
+
+            var aggregate = await _context.SensorReadingsHourly.FirstOrDefaultAsync(a => a.Hour == date.AddHours(1));
+            Assert.Null(aggregate);
+        }
+
+        [Fact]
+        public async Task AggregateHourlyData_OnlyAggregateForGivenDateAndHour()
+        {
+            var date = new DateTime(1998, 7, 16);
+            _context.SensorReadings.AddRange(
+                new SensorReading { Pressure = 100, Temperature = 20, Humidity = 50, Lux = 300, Uvs = 1, Gas = 10, Timestamp = date.AddHours(1) },
+                new SensorReading { Pressure = 200, Temperature = 22, Humidity = 55, Lux = 320, Uvs = 3, Gas = 12, Timestamp = date.AddHours(2) }
+            );
+
+            await _context.SaveChangesAsync();
+
+            await _service.AggregateHourlyData(date, 1);
+
+            var aggregate = await _context.SensorReadingsHourly.FirstOrDefaultAsync(a => a.Hour == date.AddHours(1));
+            Assert.NotNull(aggregate);
+            Assert.Equal(100, aggregate.AvgPressure);
+            Assert.Equal(100, aggregate.MaxPressure);
+            Assert.Equal(100, aggregate.MinPressure);
+
+        }
+
+        public void Dispose()
+        {
+            _context.Dispose();
+            _connection.Dispose();
+        }
+    }
+}

--- a/tests/serverTests/serverTests.csproj
+++ b/tests/serverTests/serverTests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.6" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\server\server.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This PR adds xUnit to the project and implements 10 unit tests: 4 for the middleware and 6 for the daily and hourly aggregate service.

Resolves #45