### PR TITLE
Add websocket endpoint to send new data live

### DIFF
--- a/server/Controller/SensorDataController.cs
+++ b/server/Controller/SensorDataController.cs
@@ -1,12 +1,15 @@
+using System.Net.WebSockets;
+using System.Text;
 using Microsoft.AspNetCore.Mvc;
 using project_frej.Data;
 using project_frej.Models;
+using project_frej.Services;
 
 namespace project_frej.Controllers;
 
 [ApiController]
 [Route("api/sensorData")]
-public class SensorDataController(ISensorDataRepository sensorDataRepository, ILogger<SensorDataController> logger) : ControllerBase
+public class SensorDataController(ISensorDataRepository sensorDataRepository, ILogger<SensorDataController> logger, WebSocketHandler webSocketHandler) : ControllerBase
 {
     [HttpGet("/")]
     public IActionResult GetRoot()
@@ -143,6 +146,12 @@ public class SensorDataController(ISensorDataRepository sensorDataRepository, IL
             logger.LogError(ex, "Error while fetching paged sensor data for page {PageNumber} and page size {PageSize}", pageNumber, pageSize);
             return Problem("Error while fetching paged sensor data", statusCode: 500);
         }
+    }
+
+    [HttpGet("websocket")]
+    public async Task GetSensorDataWebsocket()
+    {
+        await webSocketHandler.HandleWebSocketAsync(HttpContext);
     }
 
     [HttpGet("all")]

--- a/server/Program.cs
+++ b/server/Program.cs
@@ -12,6 +12,8 @@ builder.Services.AddDbContext<SensorDataContext>(options =>
 
 builder.Services.AddScoped<ISensorDataRepository, SensorDataRepository>();
 
+builder.Services.AddScoped<WebSocketHandler>();
+
 builder.Services.AddScoped<AggregationService>();
 builder.Services.AddHostedService<AggregationHostedService>();
 
@@ -49,9 +51,14 @@ if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI();
+    app.UseDeveloperExceptionPage();
 }
+app.UseWebSockets();
 
-app.UseMiddleware<ApiKeyPostMiddleware>();
+if (app.Environment.IsProduction())
+{
+    app.UseMiddleware<ApiKeyPostMiddleware>();
+}
 
 app.UseCors("CorsPolicy");
 

--- a/server/Services/AggregationService/WebSocketHandler.cs
+++ b/server/Services/AggregationService/WebSocketHandler.cs
@@ -1,0 +1,63 @@
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+
+using project_frej.Models;
+
+namespace project_frej.Services;
+
+public class WebSocketHandler(ILogger<WebSocketManager> logger)
+{
+    private static readonly List<WebSocket> _sockets = [];
+
+    public async Task HandleWebSocketAsync(HttpContext context)
+    {
+        logger.LogInformation("WebSocket connection established");
+        if (context.WebSockets.IsWebSocketRequest)
+        {
+            using var webSocket = await context.WebSockets.AcceptWebSocketAsync();
+            _sockets.Add(webSocket);
+
+            // Keep the connection open until the client closes it
+            await KeepConnectionOpen(webSocket);
+        }
+        else
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+        }
+    }
+
+    private static async Task KeepConnectionOpen(WebSocket webSocket)
+    {
+        var buffer = new byte[1024 * 4];
+        while (webSocket.State == WebSocketState.Open)
+        {
+            var result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closed by client", CancellationToken.None);
+                _sockets.Remove(webSocket);
+            }
+        }
+    }
+
+    public async Task NotifyClients(SensorReading sensorReading)
+    {
+        logger.LogInformation("Notifying WebSocket clients of new sensor reading: {SensorReading}", sensorReading);
+        var jsonData = JsonSerializer.Serialize(sensorReading);
+        var buffer = Encoding.UTF8.GetBytes(jsonData);
+        var segment = new ArraySegment<byte>(buffer);
+
+        foreach (var socket in _sockets.ToList())
+        {
+            if (socket.State == WebSocketState.Open)
+            {
+                await socket.SendAsync(segment, WebSocketMessageType.Text, true, CancellationToken.None);
+            }
+            else
+            {
+                _sockets.Remove(socket);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR creates a new API endpoint for live data updates. The server will keep open a connection and notify whenever a new sensor data point has been posted, and send that.

Allows for #49

Closes #33 